### PR TITLE
Update windows_logtype.json

### DIFF
--- a/src/main/resources/OSMapping/windows_logtype.json
+++ b/src/main/resources/OSMapping/windows_logtype.json
@@ -222,6 +222,10 @@
       "ecs":"winlog.event_data.ProcessName"
     },
     {
+      "raw_field":"NewProcessName",
+      "ecs":"winlog.event_data.NewProcessName"
+    },
+    {
       "raw_field":"ObjectName",
       "ecs":"winlog.computerObject.name"
     },


### PR DESCRIPTION
Add additional NewProcessName Mapping for windows logs

### Description
Fixes missing mapping in Windows event logs for NewProcessName
 
### Issues Resolved
Fixes missing mapping in Windows event logs for NewProcessName (as above)
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
